### PR TITLE
fix Not an ARRAY reference when running GapfillModel for first time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ deploy: deploy-client deploy-service
 deploy-all: deploy-client deploy-service
 deploy-client: compile-typespec deploy-docs deploy-libs deploy-scripts 
 
-deploy-service: deploy-dir deploy-monit deploy-libs deploy-service-scripts deploy-mfatoolkit
+deploy-service: deploy-dir deploy-monit deploy-libs deploy-service-scripts deploy-mfatoolkit deploy-cfg
 	$(TPAGE) $(TPAGE_ARGS) service/start_service.tt > $(TARGET)/services/$(SERVICE)/start_service
 	chmod +x $(TARGET)/services/$(SERVICE)/start_service
 	$(TPAGE) $(TPAGE_ARGS) service/stop_service.tt > $(TARGET)/services/$(SERVICE)/stop_service

--- a/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDHelper.pm
+++ b/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDHelper.pm
@@ -611,9 +611,9 @@ sub GapfillModel {
 			recursive => 1,
 			query => {type => "fba"}
 		});
-		my $index = @{$gflist};
-		for (my $i=0; $i < @{$gflist}; $i++) {
-			if ($gflist->[$i]->[0] =~ /^gf\.(\d+)$/) {
+		my $index = 0;
+		foreach my $key (keys %$gflist) {
+			if ($gflist->{$key}->[0] =~ /^gf\.(\d+)$/) {
 				if ($1 > $index) {
 					$index = $1+1;
 				}


### PR DESCRIPTION
The output from the Workspace ls() method is a mapping not an array.  Fixed the for loop to go through the returned mapping.  Also added deploy-cfg rule to deploy-service rule in Makefile so config values are written to deployment.cfg.