### PR TITLE
fix zero objective value for fba studies on gapfilled models

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/PATRICStore.pm
+++ b/lib/Bio/KBase/ObjectAPI/PATRICStore.pm
@@ -46,6 +46,7 @@ Client or server class for accessing a PATRIC workspace
 package Bio::KBase::ObjectAPI::PATRICStore;
 use Moose;
 use Bio::KBase::ObjectAPI::utilities;
+use Data::Dumper;
 
 use Class::Autouse qw(
     Bio::KBase::ObjectAPI::KBaseRegulation::Regulome
@@ -286,14 +287,14 @@ sub transform_model_from_ws {
 	my $obj = Bio::KBase::ObjectAPI::KBaseFBA::FBAModel->new($data);
 	$obj->parent($self);
 	my $gflist = $self->workspace()->ls({
-		paths => [$meta->[2]."gapfilling"],
+		paths => [$meta->[2].".".$meta->[0]."/gapfilling"],
 		excludeDirectories => 1,
 		excludeObjects => 0,
 		recursive => 1,
 		query => {type => "fba"}
 	});
-	if (defined($gflist->{$meta->[2]."gapfilling"})) {
-		$gflist = $gflist->{$meta->[2]."gapfilling"};
+	if (defined($gflist->{$meta->[2].".".$meta->[0]."/gapfilling"})) {
+		$gflist = $gflist->{$meta->[2].".".$meta->[0]."/gapfilling"};
 		for (my $i=0; $i < @{$gflist}; $i++) {
 			if ($gflist->[$i]->[0] ne Bio::KBase::ObjectAPI::utilities::get_global("gapfill name")) {
 				if ($gflist->[$i]->[7]->{integrated} == 1) {

--- a/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDHelper.pm
+++ b/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDHelper.pm
@@ -571,6 +571,9 @@ sub GapfillModel {
 		exp_raw_data => {},
 		source_model => undef,
 		integrate_solution => 0,
+		fva => 0,
+		minimizeflux => 0,
+		findminmedia => 0,
 	});
 	my $log = Log::Log4perl->get_logger("ProbModelSEEDHelper");
     $log->info("Starting gap fill for model ".$parameters->{model}." on media ".$parameters->{media});


### PR DESCRIPTION
When running the FluxBalanceAnalysis() method on a gap filled model, the returned objective value was always zero.  The problem was in the transform_model_from_ws() function which wasn't processing the gapfilling folder correctly.  Just a note for future reference that the folder structure for models is baked into the code so if it changes there are multiple places where it needs to be updated.

I'm still a little confused by line 299.  Only the GapfillModel() method sets the global parameter "gapfill name" so that other places where a model is retrieved from the workspace cause this warning message:

Use of uninitialized value in string ne at /data2/microbiome/software/patric/dev-20150521/deployment/lib/Bio/KBase/ObjectAPI/PATRICStore.pm line 299.