### PR TITLE
Fix #4 - make keys for object references consistent

### DIFF
--- a/ProbModelSEED.spec
+++ b/ProbModelSEED.spec
@@ -84,8 +84,8 @@ module ProbModelSEED {
     typedef structure {
 		Timestamp rundate;
 		gapfill_id id;
-		ref gapfill;
-		ref media;
+		ref ref;
+		ref media_ref;
 		bool integrated;
 		int integrated_solution;
 		list<list<gapfill_reaction>> solution_reactions;
@@ -94,9 +94,9 @@ module ProbModelSEED {
     typedef structure {
 		Timestamp rundate;
 		fba_id id;
-		ref fba;
+		ref ref;
 		float objective;
-		ref media;
+		ref media_ref;
 		string objective_function;
     } fba_data;
     
@@ -110,7 +110,7 @@ module ProbModelSEED {
     typedef structure {
 		Timestamp rundate;
 		edit_id id;
-		ref edit;
+		ref ref;
 		list<reaction_id> reactions_to_delete;
 		mapping<reaction_id,reaction_direction> altered_directions;
 		mapping<reaction_id,list<list<list<feature_id> > > > altered_gpr;
@@ -119,11 +119,13 @@ module ProbModelSEED {
     } edit_data;
     
     typedef structure {
+ 		Timestamp rundate;
 		string id;
 		string source;
 		string source_id;
 		string name;
 		string type;
+		ref ref;
 		ref genome_ref;
 		ref template_ref;
 		int fba_count;

--- a/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDClient.pm
+++ b/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDClient.pm
@@ -130,24 +130,31 @@ print_model_stats_params is a reference to a hash where the following keys are d
 	models has a value which is a reference to a list where each element is a ref
 ref is a string
 ModelStats is a reference to a hash where the following keys are defined:
+	rundate has a value which is a Timestamp
 	id has a value which is a string
 	source has a value which is a string
 	source_id has a value which is a string
 	name has a value which is a string
 	type has a value which is a string
-	genome has a value which is a ref
-	template has a value which is a ref
+	ref has a value which is a ref
+	genome_ref has a value which is a ref
+	template_ref has a value which is a ref
 	fba_count has a value which is an int
 	integrated_gapfills has a value which is an int
 	unintegrated_gapfills has a value which is an int
 	gene_associated_reactions has a value which is an int
 	gapfilled_reactions has a value which is an int
-	spontaneous_reactions has a value which is an int
 	num_genes has a value which is an int
 	num_compounds has a value which is an int
 	num_reactions has a value which is an int
 	num_biomasses has a value which is an int
 	num_biomass_compounds has a value which is an int
+	num_compartments has a value which is an int
+	biomasses has a value which is a reference to a list where each element is a string
+	reactions has a value which is a reference to a list where each element is a string
+	genes has a value which is a reference to a list where each element is a string
+	biomasscpds has a value which is a reference to a list where each element is a string
+Timestamp is a string
 
 </pre>
 
@@ -161,24 +168,31 @@ print_model_stats_params is a reference to a hash where the following keys are d
 	models has a value which is a reference to a list where each element is a ref
 ref is a string
 ModelStats is a reference to a hash where the following keys are defined:
+	rundate has a value which is a Timestamp
 	id has a value which is a string
 	source has a value which is a string
 	source_id has a value which is a string
 	name has a value which is a string
 	type has a value which is a string
-	genome has a value which is a ref
-	template has a value which is a ref
+	ref has a value which is a ref
+	genome_ref has a value which is a ref
+	template_ref has a value which is a ref
 	fba_count has a value which is an int
 	integrated_gapfills has a value which is an int
 	unintegrated_gapfills has a value which is an int
 	gene_associated_reactions has a value which is an int
 	gapfilled_reactions has a value which is an int
-	spontaneous_reactions has a value which is an int
 	num_genes has a value which is an int
 	num_compounds has a value which is an int
 	num_reactions has a value which is an int
 	num_biomasses has a value which is an int
 	num_biomass_compounds has a value which is an int
+	num_compartments has a value which is an int
+	biomasses has a value which is a reference to a list where each element is a string
+	reactions has a value which is a reference to a list where each element is a string
+	genes has a value which is a reference to a list where each element is a string
+	biomasscpds has a value which is a reference to a list where each element is a string
+Timestamp is a string
 
 
 =end text
@@ -257,8 +271,8 @@ ref is a string
 gapfill_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a gapfill_id
-	gapfill has a value which is a ref
-	media has a value which is a ref
+	ref has a value which is a ref
+	media_ref has a value which is a ref
 	integrated has a value which is a bool
 	integrated_solution has a value which is an int
 	solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -285,8 +299,8 @@ ref is a string
 gapfill_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a gapfill_id
-	gapfill has a value which is a ref
-	media has a value which is a ref
+	ref has a value which is a ref
+	media_ref has a value which is a ref
 	integrated has a value which is a bool
 	integrated_solution has a value which is an int
 	solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -380,8 +394,8 @@ gapfill_command is a string
 gapfill_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a gapfill_id
-	gapfill has a value which is a ref
-	media has a value which is a ref
+	ref has a value which is a ref
+	media_ref has a value which is a ref
 	integrated has a value which is a bool
 	integrated_solution has a value which is an int
 	solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -411,8 +425,8 @@ gapfill_command is a string
 gapfill_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a gapfill_id
-	gapfill has a value which is a ref
-	media has a value which is a ref
+	ref has a value which is a ref
+	media_ref has a value which is a ref
 	integrated has a value which is a bool
 	integrated_solution has a value which is an int
 	solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -501,9 +515,9 @@ ref is a string
 fba_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a fba_id
-	fba has a value which is a ref
+	ref has a value which is a ref
 	objective has a value which is a float
-	media has a value which is a ref
+	media_ref has a value which is a ref
 	objective_function has a value which is a string
 Timestamp is a string
 fba_id is a string
@@ -522,9 +536,9 @@ ref is a string
 fba_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a fba_id
-	fba has a value which is a ref
+	ref has a value which is a ref
 	objective has a value which is a float
-	media has a value which is a ref
+	media_ref has a value which is a ref
 	objective_function has a value which is a string
 Timestamp is a string
 fba_id is a string
@@ -610,9 +624,9 @@ fba_id is a string
 fba_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a fba_id
-	fba has a value which is a ref
+	ref has a value which is a ref
 	objective has a value which is a float
-	media has a value which is a ref
+	media_ref has a value which is a ref
 	objective_function has a value which is a string
 Timestamp is a string
 
@@ -634,9 +648,9 @@ fba_id is a string
 fba_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a fba_id
-	fba has a value which is a ref
+	ref has a value which is a ref
 	objective has a value which is a float
-	media has a value which is a ref
+	media_ref has a value which is a ref
 	objective_function has a value which is a string
 Timestamp is a string
 
@@ -1028,24 +1042,31 @@ sub delete_model
 <pre>
 $output is a reference to a list where each element is a ModelStats
 ModelStats is a reference to a hash where the following keys are defined:
+	rundate has a value which is a Timestamp
 	id has a value which is a string
 	source has a value which is a string
 	source_id has a value which is a string
 	name has a value which is a string
 	type has a value which is a string
-	genome has a value which is a ref
-	template has a value which is a ref
+	ref has a value which is a ref
+	genome_ref has a value which is a ref
+	template_ref has a value which is a ref
 	fba_count has a value which is an int
 	integrated_gapfills has a value which is an int
 	unintegrated_gapfills has a value which is an int
 	gene_associated_reactions has a value which is an int
 	gapfilled_reactions has a value which is an int
-	spontaneous_reactions has a value which is an int
 	num_genes has a value which is an int
 	num_compounds has a value which is an int
 	num_reactions has a value which is an int
 	num_biomasses has a value which is an int
 	num_biomass_compounds has a value which is an int
+	num_compartments has a value which is an int
+	biomasses has a value which is a reference to a list where each element is a string
+	reactions has a value which is a reference to a list where each element is a string
+	genes has a value which is a reference to a list where each element is a string
+	biomasscpds has a value which is a reference to a list where each element is a string
+Timestamp is a string
 ref is a string
 
 </pre>
@@ -1056,24 +1077,31 @@ ref is a string
 
 $output is a reference to a list where each element is a ModelStats
 ModelStats is a reference to a hash where the following keys are defined:
+	rundate has a value which is a Timestamp
 	id has a value which is a string
 	source has a value which is a string
 	source_id has a value which is a string
 	name has a value which is a string
 	type has a value which is a string
-	genome has a value which is a ref
-	template has a value which is a ref
+	ref has a value which is a ref
+	genome_ref has a value which is a ref
+	template_ref has a value which is a ref
 	fba_count has a value which is an int
 	integrated_gapfills has a value which is an int
 	unintegrated_gapfills has a value which is an int
 	gene_associated_reactions has a value which is an int
 	gapfilled_reactions has a value which is an int
-	spontaneous_reactions has a value which is an int
 	num_genes has a value which is an int
 	num_compounds has a value which is an int
 	num_reactions has a value which is an int
 	num_biomasses has a value which is an int
 	num_biomass_compounds has a value which is an int
+	num_compartments has a value which is an int
+	biomasses has a value which is a reference to a list where each element is a string
+	reactions has a value which is a reference to a list where each element is a string
+	genes has a value which is a reference to a list where each element is a string
+	biomasscpds has a value which is a reference to a list where each element is a string
+Timestamp is a string
 ref is a string
 
 
@@ -1145,7 +1173,7 @@ ref is a string
 edit_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is an edit_id
-	edit has a value which is a ref
+	ref has a value which is a ref
 	reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 	altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 	altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -1185,7 +1213,7 @@ ref is a string
 edit_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is an edit_id
-	edit has a value which is a ref
+	ref has a value which is a ref
 	reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 	altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 	altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -1292,7 +1320,7 @@ gapfill_command is a string
 edit_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is an edit_id
-	edit has a value which is a ref
+	ref has a value which is a ref
 	reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 	altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 	altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -1335,7 +1363,7 @@ gapfill_command is a string
 edit_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is an edit_id
-	edit has a value which is a ref
+	ref has a value which is a ref
 	reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 	altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 	altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -2613,8 +2641,8 @@ compartment has a value which is a string
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is a gapfill_id
-gapfill has a value which is a ref
-media has a value which is a ref
+ref has a value which is a ref
+media_ref has a value which is a ref
 integrated has a value which is a bool
 integrated_solution has a value which is an int
 solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -2628,8 +2656,8 @@ solution_reactions has a value which is a reference to a list where each element
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is a gapfill_id
-gapfill has a value which is a ref
-media has a value which is a ref
+ref has a value which is a ref
+media_ref has a value which is a ref
 integrated has a value which is a bool
 integrated_solution has a value which is an int
 solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -2655,9 +2683,9 @@ solution_reactions has a value which is a reference to a list where each element
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is a fba_id
-fba has a value which is a ref
+ref has a value which is a ref
 objective has a value which is a float
-media has a value which is a ref
+media_ref has a value which is a ref
 objective_function has a value which is a string
 
 </pre>
@@ -2669,9 +2697,9 @@ objective_function has a value which is a string
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is a fba_id
-fba has a value which is a ref
+ref has a value which is a ref
 objective has a value which is a float
-media has a value which is a ref
+media_ref has a value which is a ref
 objective_function has a value which is a string
 
 
@@ -2739,7 +2767,7 @@ direction has a value which is a reaction_direction
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is an edit_id
-edit has a value which is a ref
+ref has a value which is a ref
 reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -2758,7 +2786,7 @@ altered_biomass_compound has a value which is a reference to a hash where the ke
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is an edit_id
-edit has a value which is a ref
+ref has a value which is a ref
 reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -2787,24 +2815,30 @@ altered_biomass_compound has a value which is a reference to a hash where the ke
 
 <pre>
 a reference to a hash where the following keys are defined:
+rundate has a value which is a Timestamp
 id has a value which is a string
 source has a value which is a string
 source_id has a value which is a string
 name has a value which is a string
 type has a value which is a string
-genome has a value which is a ref
-template has a value which is a ref
+ref has a value which is a ref
+genome_ref has a value which is a ref
+template_ref has a value which is a ref
 fba_count has a value which is an int
 integrated_gapfills has a value which is an int
 unintegrated_gapfills has a value which is an int
 gene_associated_reactions has a value which is an int
 gapfilled_reactions has a value which is an int
-spontaneous_reactions has a value which is an int
 num_genes has a value which is an int
 num_compounds has a value which is an int
 num_reactions has a value which is an int
 num_biomasses has a value which is an int
 num_biomass_compounds has a value which is an int
+num_compartments has a value which is an int
+biomasses has a value which is a reference to a list where each element is a string
+reactions has a value which is a reference to a list where each element is a string
+genes has a value which is a reference to a list where each element is a string
+biomasscpds has a value which is a reference to a list where each element is a string
 
 </pre>
 
@@ -2813,24 +2847,30 @@ num_biomass_compounds has a value which is an int
 =begin text
 
 a reference to a hash where the following keys are defined:
+rundate has a value which is a Timestamp
 id has a value which is a string
 source has a value which is a string
 source_id has a value which is a string
 name has a value which is a string
 type has a value which is a string
-genome has a value which is a ref
-template has a value which is a ref
+ref has a value which is a ref
+genome_ref has a value which is a ref
+template_ref has a value which is a ref
 fba_count has a value which is an int
 integrated_gapfills has a value which is an int
 unintegrated_gapfills has a value which is an int
 gene_associated_reactions has a value which is an int
 gapfilled_reactions has a value which is an int
-spontaneous_reactions has a value which is an int
 num_genes has a value which is an int
 num_compounds has a value which is an int
 num_reactions has a value which is an int
 num_biomasses has a value which is an int
 num_biomass_compounds has a value which is an int
+num_compartments has a value which is an int
+biomasses has a value which is a reference to a list where each element is a string
+reactions has a value which is a reference to a list where each element is a string
+genes has a value which is a reference to a list where each element is a string
+biomasscpds has a value which is a reference to a list where each element is a string
 
 
 =end text

--- a/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDImpl.pm
+++ b/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDImpl.pm
@@ -328,24 +328,31 @@ print_model_stats_params is a reference to a hash where the following keys are d
 	models has a value which is a reference to a list where each element is a ref
 ref is a string
 ModelStats is a reference to a hash where the following keys are defined:
+	rundate has a value which is a Timestamp
 	id has a value which is a string
 	source has a value which is a string
 	source_id has a value which is a string
 	name has a value which is a string
 	type has a value which is a string
-	genome has a value which is a ref
-	template has a value which is a ref
+	ref has a value which is a ref
+	genome_ref has a value which is a ref
+	template_ref has a value which is a ref
 	fba_count has a value which is an int
 	integrated_gapfills has a value which is an int
 	unintegrated_gapfills has a value which is an int
 	gene_associated_reactions has a value which is an int
 	gapfilled_reactions has a value which is an int
-	spontaneous_reactions has a value which is an int
 	num_genes has a value which is an int
 	num_compounds has a value which is an int
 	num_reactions has a value which is an int
 	num_biomasses has a value which is an int
 	num_biomass_compounds has a value which is an int
+	num_compartments has a value which is an int
+	biomasses has a value which is a reference to a list where each element is a string
+	reactions has a value which is a reference to a list where each element is a string
+	genes has a value which is a reference to a list where each element is a string
+	biomasscpds has a value which is a reference to a list where each element is a string
+Timestamp is a string
 
 </pre>
 
@@ -359,24 +366,31 @@ print_model_stats_params is a reference to a hash where the following keys are d
 	models has a value which is a reference to a list where each element is a ref
 ref is a string
 ModelStats is a reference to a hash where the following keys are defined:
+	rundate has a value which is a Timestamp
 	id has a value which is a string
 	source has a value which is a string
 	source_id has a value which is a string
 	name has a value which is a string
 	type has a value which is a string
-	genome has a value which is a ref
-	template has a value which is a ref
+	ref has a value which is a ref
+	genome_ref has a value which is a ref
+	template_ref has a value which is a ref
 	fba_count has a value which is an int
 	integrated_gapfills has a value which is an int
 	unintegrated_gapfills has a value which is an int
 	gene_associated_reactions has a value which is an int
 	gapfilled_reactions has a value which is an int
-	spontaneous_reactions has a value which is an int
 	num_genes has a value which is an int
 	num_compounds has a value which is an int
 	num_reactions has a value which is an int
 	num_biomasses has a value which is an int
 	num_biomass_compounds has a value which is an int
+	num_compartments has a value which is an int
+	biomasses has a value which is a reference to a list where each element is a string
+	reactions has a value which is a reference to a list where each element is a string
+	genes has a value which is a reference to a list where each element is a string
+	biomasscpds has a value which is a reference to a list where each element is a string
+Timestamp is a string
 
 
 =end text
@@ -440,8 +454,8 @@ ref is a string
 gapfill_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a gapfill_id
-	gapfill has a value which is a ref
-	media has a value which is a ref
+	ref has a value which is a ref
+	media_ref has a value which is a ref
 	integrated has a value which is a bool
 	integrated_solution has a value which is an int
 	solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -468,8 +482,8 @@ ref is a string
 gapfill_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a gapfill_id
-	gapfill has a value which is a ref
-	media has a value which is a ref
+	ref has a value which is a ref
+	media_ref has a value which is a ref
 	integrated has a value which is a bool
 	integrated_solution has a value which is an int
 	solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -556,8 +570,8 @@ gapfill_command is a string
 gapfill_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a gapfill_id
-	gapfill has a value which is a ref
-	media has a value which is a ref
+	ref has a value which is a ref
+	media_ref has a value which is a ref
 	integrated has a value which is a bool
 	integrated_solution has a value which is an int
 	solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -587,8 +601,8 @@ gapfill_command is a string
 gapfill_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a gapfill_id
-	gapfill has a value which is a ref
-	media has a value which is a ref
+	ref has a value which is a ref
+	media_ref has a value which is a ref
 	integrated has a value which is a bool
 	integrated_solution has a value which is an int
 	solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -718,9 +732,9 @@ ref is a string
 fba_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a fba_id
-	fba has a value which is a ref
+	ref has a value which is a ref
 	objective has a value which is a float
-	media has a value which is a ref
+	media_ref has a value which is a ref
 	objective_function has a value which is a string
 Timestamp is a string
 fba_id is a string
@@ -739,9 +753,9 @@ ref is a string
 fba_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a fba_id
-	fba has a value which is a ref
+	ref has a value which is a ref
 	objective has a value which is a float
-	media has a value which is a ref
+	media_ref has a value which is a ref
 	objective_function has a value which is a string
 Timestamp is a string
 fba_id is a string
@@ -819,9 +833,9 @@ fba_id is a string
 fba_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a fba_id
-	fba has a value which is a ref
+	ref has a value which is a ref
 	objective has a value which is a float
-	media has a value which is a ref
+	media_ref has a value which is a ref
 	objective_function has a value which is a string
 Timestamp is a string
 
@@ -843,9 +857,9 @@ fba_id is a string
 fba_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is a fba_id
-	fba has a value which is a ref
+	ref has a value which is a ref
 	objective has a value which is a float
-	media has a value which is a ref
+	media_ref has a value which is a ref
 	objective_function has a value which is a string
 Timestamp is a string
 
@@ -1226,24 +1240,31 @@ sub delete_model
 <pre>
 $output is a reference to a list where each element is a ModelStats
 ModelStats is a reference to a hash where the following keys are defined:
+	rundate has a value which is a Timestamp
 	id has a value which is a string
 	source has a value which is a string
 	source_id has a value which is a string
 	name has a value which is a string
 	type has a value which is a string
-	genome has a value which is a ref
-	template has a value which is a ref
+	ref has a value which is a ref
+	genome_ref has a value which is a ref
+	template_ref has a value which is a ref
 	fba_count has a value which is an int
 	integrated_gapfills has a value which is an int
 	unintegrated_gapfills has a value which is an int
 	gene_associated_reactions has a value which is an int
 	gapfilled_reactions has a value which is an int
-	spontaneous_reactions has a value which is an int
 	num_genes has a value which is an int
 	num_compounds has a value which is an int
 	num_reactions has a value which is an int
 	num_biomasses has a value which is an int
 	num_biomass_compounds has a value which is an int
+	num_compartments has a value which is an int
+	biomasses has a value which is a reference to a list where each element is a string
+	reactions has a value which is a reference to a list where each element is a string
+	genes has a value which is a reference to a list where each element is a string
+	biomasscpds has a value which is a reference to a list where each element is a string
+Timestamp is a string
 ref is a string
 
 </pre>
@@ -1254,24 +1275,31 @@ ref is a string
 
 $output is a reference to a list where each element is a ModelStats
 ModelStats is a reference to a hash where the following keys are defined:
+	rundate has a value which is a Timestamp
 	id has a value which is a string
 	source has a value which is a string
 	source_id has a value which is a string
 	name has a value which is a string
 	type has a value which is a string
-	genome has a value which is a ref
-	template has a value which is a ref
+	ref has a value which is a ref
+	genome_ref has a value which is a ref
+	template_ref has a value which is a ref
 	fba_count has a value which is an int
 	integrated_gapfills has a value which is an int
 	unintegrated_gapfills has a value which is an int
 	gene_associated_reactions has a value which is an int
 	gapfilled_reactions has a value which is an int
-	spontaneous_reactions has a value which is an int
 	num_genes has a value which is an int
 	num_compounds has a value which is an int
 	num_reactions has a value which is an int
 	num_biomasses has a value which is an int
 	num_biomass_compounds has a value which is an int
+	num_compartments has a value which is an int
+	biomasses has a value which is a reference to a list where each element is a string
+	reactions has a value which is a reference to a list where each element is a string
+	genes has a value which is a reference to a list where each element is a string
+	biomasscpds has a value which is a reference to a list where each element is a string
+Timestamp is a string
 ref is a string
 
 
@@ -1337,7 +1365,7 @@ ref is a string
 edit_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is an edit_id
-	edit has a value which is a ref
+	ref has a value which is a ref
 	reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 	altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 	altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -1377,7 +1405,7 @@ ref is a string
 edit_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is an edit_id
-	edit has a value which is a ref
+	ref has a value which is a ref
 	reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 	altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 	altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -1476,7 +1504,7 @@ gapfill_command is a string
 edit_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is an edit_id
-	edit has a value which is a ref
+	ref has a value which is a ref
 	reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 	altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 	altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -1519,7 +1547,7 @@ gapfill_command is a string
 edit_data is a reference to a hash where the following keys are defined:
 	rundate has a value which is a Timestamp
 	id has a value which is an edit_id
-	edit has a value which is a ref
+	ref has a value which is a ref
 	reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 	altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 	altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -2790,8 +2818,8 @@ compartment has a value which is a string
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is a gapfill_id
-gapfill has a value which is a ref
-media has a value which is a ref
+ref has a value which is a ref
+media_ref has a value which is a ref
 integrated has a value which is a bool
 integrated_solution has a value which is an int
 solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -2805,8 +2833,8 @@ solution_reactions has a value which is a reference to a list where each element
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is a gapfill_id
-gapfill has a value which is a ref
-media has a value which is a ref
+ref has a value which is a ref
+media_ref has a value which is a ref
 integrated has a value which is a bool
 integrated_solution has a value which is an int
 solution_reactions has a value which is a reference to a list where each element is a reference to a list where each element is a gapfill_reaction
@@ -2832,9 +2860,9 @@ solution_reactions has a value which is a reference to a list where each element
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is a fba_id
-fba has a value which is a ref
+ref has a value which is a ref
 objective has a value which is a float
-media has a value which is a ref
+media_ref has a value which is a ref
 objective_function has a value which is a string
 
 </pre>
@@ -2846,9 +2874,9 @@ objective_function has a value which is a string
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is a fba_id
-fba has a value which is a ref
+ref has a value which is a ref
 objective has a value which is a float
-media has a value which is a ref
+media_ref has a value which is a ref
 objective_function has a value which is a string
 
 
@@ -2916,7 +2944,7 @@ direction has a value which is a reaction_direction
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is an edit_id
-edit has a value which is a ref
+ref has a value which is a ref
 reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -2935,7 +2963,7 @@ altered_biomass_compound has a value which is a reference to a hash where the ke
 a reference to a hash where the following keys are defined:
 rundate has a value which is a Timestamp
 id has a value which is an edit_id
-edit has a value which is a ref
+ref has a value which is a ref
 reactions_to_delete has a value which is a reference to a list where each element is a reaction_id
 altered_directions has a value which is a reference to a hash where the key is a reaction_id and the value is a reaction_direction
 altered_gpr has a value which is a reference to a hash where the key is a reaction_id and the value is a reference to a list where each element is a reference to a list where each element is a reference to a list where each element is a feature_id
@@ -2964,24 +2992,30 @@ altered_biomass_compound has a value which is a reference to a hash where the ke
 
 <pre>
 a reference to a hash where the following keys are defined:
+rundate has a value which is a Timestamp
 id has a value which is a string
 source has a value which is a string
 source_id has a value which is a string
 name has a value which is a string
 type has a value which is a string
-genome has a value which is a ref
-template has a value which is a ref
+ref has a value which is a ref
+genome_ref has a value which is a ref
+template_ref has a value which is a ref
 fba_count has a value which is an int
 integrated_gapfills has a value which is an int
 unintegrated_gapfills has a value which is an int
 gene_associated_reactions has a value which is an int
 gapfilled_reactions has a value which is an int
-spontaneous_reactions has a value which is an int
 num_genes has a value which is an int
 num_compounds has a value which is an int
 num_reactions has a value which is an int
 num_biomasses has a value which is an int
 num_biomass_compounds has a value which is an int
+num_compartments has a value which is an int
+biomasses has a value which is a reference to a list where each element is a string
+reactions has a value which is a reference to a list where each element is a string
+genes has a value which is a reference to a list where each element is a string
+biomasscpds has a value which is a reference to a list where each element is a string
 
 </pre>
 
@@ -2990,24 +3024,30 @@ num_biomass_compounds has a value which is an int
 =begin text
 
 a reference to a hash where the following keys are defined:
+rundate has a value which is a Timestamp
 id has a value which is a string
 source has a value which is a string
 source_id has a value which is a string
 name has a value which is a string
 type has a value which is a string
-genome has a value which is a ref
-template has a value which is a ref
+ref has a value which is a ref
+genome_ref has a value which is a ref
+template_ref has a value which is a ref
 fba_count has a value which is an int
 integrated_gapfills has a value which is an int
 unintegrated_gapfills has a value which is an int
 gene_associated_reactions has a value which is an int
 gapfilled_reactions has a value which is an int
-spontaneous_reactions has a value which is an int
 num_genes has a value which is an int
 num_compounds has a value which is an int
 num_reactions has a value which is an int
 num_biomasses has a value which is an int
 num_biomass_compounds has a value which is an int
+num_compartments has a value which is an int
+biomasses has a value which is a reference to a list where each element is a string
+reactions has a value which is a reference to a list where each element is a string
+genes has a value which is a reference to a list where each element is a string
+biomasscpds has a value which is a reference to a list where each element is a string
 
 
 =end text

--- a/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDImpl.pm
+++ b/lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDImpl.pm
@@ -118,8 +118,8 @@ sub _list_fba_studies {
 			my $element = {
 				rundate => $list->[$i]->[3],
 				id => $list->[$i]->[0],
-				fba => $list->[$i]->[2].$list->[$i]->[0],
-				media => $list->[$i]->[7]->{media},
+				"ref" => $list->[$i]->[2].$list->[$i]->[0],
+				media_ref => $list->[$i]->[7]->{media},
 				objective => $list->[$i]->[7]->{objective},
 				objective_function => $list->[$i]->[8]->{objective_function},				
 			};
@@ -197,7 +197,7 @@ sub _list_models {
 	return $output;
 }
 
-sub _list_gapfill_studies {
+sub _list_gapfill_solutions {
 	my ($self,$input) = @_;
 	$input = $self->helper()->validate_args($input,["model"],{});
     $input->{model_meta} = $self->helper()->get_model_meta($input->{model});
@@ -216,8 +216,8 @@ sub _list_gapfill_studies {
 			$output->{$id} = {
 				rundate => $gflist->[$i]->[3],
 				id => $id,
-				gapfill => $gflist->[$i]->[2].$gflist->[$i]->[0],
-				media => $gflist->[$i]->[7]->{media},
+				"ref" => $gflist->[$i]->[2].$gflist->[$i]->[0],
+				media_ref => $gflist->[$i]->[7]->{media},
 				integrated => $gflist->[$i]->[7]->{integrated},
 				integrated_solution => $gflist->[$i]->[7]->{integrated_solution},
 				solution_reactions => []
@@ -264,7 +264,7 @@ sub _list_model_edits {
 				rundate => $list->[$i]->[3],
 				integrated => $list->[$i]->[7]->{integrated},
 				id => $id,
-				edit => $list->[$i]->[2].$list->[$i]->[0],
+				"ref" => $list->[$i]->[2].$list->[$i]->[0],
 				reactions_to_delete => $data->{reactions_to_delete},
 				altered_directions => $data->{altered_directions},
 				altered_gpr => $data->{altered_gpr},
@@ -513,7 +513,7 @@ sub list_gapfill_solutions
     #BEGIN list_gapfill_solutions
     $input = $self->initialize_call($input);
     $input = $self->helper()->validate_args($input,["model"],{});
-	my $hash = $self->_list_gapfill_studies($input);
+	my $hash = $self->_list_gapfill_solutions($input);
 	my $output = [];
 	foreach my $key (keys(%{$hash})) {
 		push(@{$output},$hash->{$key});
@@ -633,7 +633,7 @@ sub manage_gapfill_solutions
     $input = $self->helper()->validate_args($input,["model","commands"],{
     	selected_solutions => {}
     });
-    my $gflist = $self->_list_gapfill_studies($input);
+    my $gflist = $self->_list_gapfill_solutions($input);
     my $rmlist = [];
     my $updatelist = [];
     $output = {};


### PR DESCRIPTION
Updated the keys in the mappings returned by the list methods to be consistent. 