### PR TITLE
Minor fix to enable recognition of water and protons

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/KBaseBiochem/Biochemistry.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseBiochem/Biochemistry.pm
@@ -1568,7 +1568,9 @@ sub checkForDuplicateCue {
 
 sub checkForProton {
     my ($self) = @_;
-    my $obj=$self->getObjectByAlias("compounds","cpd00067","ModelSEED");
+    my $obj=$self->getObject("compounds","cpd00067");
+    return $obj if $obj;
+    $obj=$self->getObjectByAlias("compounds","cpd00067","ModelSEED");
     return $obj if $obj;
     $obj=$self->getObjectByAlias("compounds","C00080","KEGG");
     return $obj if $obj;
@@ -1579,7 +1581,9 @@ sub checkForProton {
 
 sub checkForWater {
     my ($self) = @_;
-    my $obj=$self->getObjectByAlias("compounds","cpd00001","ModelSEED");
+    my $obj=$self->getObject("compounds","cpd00001");
+    return $obj if $obj;
+    $obj=$self->getObjectByAlias("compounds","cpd00001","ModelSEED");
     return $obj if $obj;
     $obj=$self->getObjectByAlias("compounds","C00001","KEGG");
     return $obj if $obj;


### PR DESCRIPTION
This, I believe should address the "Could not find water" error Mike reported in https://github.com/ModelSEED/ModelSEEDDatabase/issues/2

One thing I completely forgot in our discussion of this particular issue is the simple fact that if you're creating/adding reactions to an initially empty biochemistry object, then that object needs to have water and protons defined in it anyway.

It then follows that, for this purpose, I use something like the following code when creating any new biochemistry object, in order to define water and protons:

```
my $NewBiochem = Bio::KBase::ObjectAPI::KBaseBiochem::Biochemistry->new($data);
$NewBiochem->parent($Store);

my $Proton = {id=>'cpd00067', name=>'H+', formula=>'H', charge=>1, deltaG=>10000000, deltaGErr=>10000000};
$NewBiochem->add("compounds",$Proton);

push(@{$NewBiochem->compound_aliases()->{cpd00067}{ModelSEED}},'cpd00067');
push(@{$NewBiochem->compound_aliases()->{cpd00067}{name}},'H+');
push(@{$NewBiochem->compound_aliases()->{cpd00067}{name}},'Proton');
push(@{$NewBiochem->compound_aliases()->{cpd00067}{searchname}},'proton');

my $Water = {id=>'cpd00001', name=>'Water', formula=>'H2O', charge=>0, deltaG=>10000000, deltaGErr=>10000000};
$NewBiochem->add("compounds",$Water);

push(@{$NewBiochem->compound_aliases()->{cpd00001}{ModelSEED}},'cpd00001');
push(@{$NewBiochem->compound_aliases()->{cpd00001}{name}},'H2O');
push(@{$NewBiochem->compound_aliases()->{cpd00001}{name}},'Water');
push(@{$NewBiochem->compound_aliases()->{cpd00001}{searchname}},'water');
```