### PR TITLE
Fixing several bugs in model reconstruction process

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/functions.pm
+++ b/lib/Bio/KBase/ObjectAPI/functions.pm
@@ -339,7 +339,8 @@ sub func_build_metabolic_model {
 	});
 	#Getting genome
 	$handler->util_log("Retrieving genome.");
-	my $genome = $handler->util_get_object($params->{genome_workspace}."/".$params->{genome_id});
+	my $genome = $handler->util_get_object($params->{genome_workspace}."/".$params->{genome_id}."/genome");
+
 	#Classifying genome
 	if ($params->{template_id} eq "auto") {
 		if (!defined($params->{template_workspace})) {


### PR DESCRIPTION
Here we have some re-organization of the plant annotation pipeline within the ModelReconstruction() function, a bug fix for calling genome within func_build_metabolic_model() and a bug fix for when list_models() is called and a user doesn't have either of the `plantseed` or `modelseed` folders present.